### PR TITLE
FISH-174 Add jakarta.* to javax.* invert support to org.eclipse.transformer.maven plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,27 @@ To use the snapshot transformer maven plugin in your Maven build, you can config
 </pluginRepositories>
 ```
 
+Add the following plugin to `plugins` section of pom.xml:
+
+```
+<plugin>
+    <groupId>org.eclipse.transformer</groupId>
+    <artifactId>org.eclipse.transformer.maven</artifactId>
+    <version>0.2.2-SNAPSHOT</version>
+    <executions>
+        <execution>
+            <phase>test-compile</phase>
+            <configuration>
+                <invert>true</invert>
+            </configuration>
+            <goals>
+                <goal>run</goal>
+            </goals>
+        </execution>
+    </executions>
+</plugin>
+```
+
 ## Contributing
 
 If you would like to contribute to Transformer, check out the [contributing guide](CONTRIBUTING.md) for more information.

--- a/org.eclipse.transformer.maven/pom.xml
+++ b/org.eclipse.transformer.maven/pom.xml
@@ -66,10 +66,10 @@
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-compat</artifactId>
 		</dependency>
-                <dependency>
-                        <groupId>commons-io</groupId>
-                        <artifactId>commons-io</artifactId>
-                </dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+		</dependency>
 
 		<!-- TESTS -->
 		<dependency>

--- a/org.eclipse.transformer.maven/pom.xml
+++ b/org.eclipse.transformer.maven/pom.xml
@@ -66,6 +66,10 @@
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-compat</artifactId>
 		</dependency>
+                <dependency>
+                        <groupId>commons-io</groupId>
+                        <artifactId>commons-io</artifactId>
+                </dependency>
 
 		<!-- TESTS -->
 		<dependency>

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/Transformer.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/Transformer.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020-2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/pom.xml
+++ b/pom.xml
@@ -501,7 +501,12 @@
 				<artifactId>javaee-api</artifactId>
 				<version>8.0.1</version>
 				<scope>test</scope>
-			</dependency>
+                        </dependency>
+                        <dependency>
+                                <groupId>commons-io</groupId>
+                                <artifactId>commons-io</artifactId>
+                                <version>2.8.0</version>
+                        </dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -501,12 +501,12 @@
 				<artifactId>javaee-api</artifactId>
 				<version>8.0.1</version>
 				<scope>test</scope>
-                        </dependency>
-                        <dependency>
-                                <groupId>commons-io</groupId>
-                                <artifactId>commons-io</artifactId>
-                                <version>2.8.0</version>
-                        </dependency>
+			</dependency>
+			<dependency>
+				<groupId>commons-io</groupId>
+				<artifactId>commons-io</artifactId>
+				<version>2.8.0</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 


### PR DESCRIPTION
This PR fixes the issue in Eclipse Transformer Maven plugin and adding the invert transformation support.

````
            <plugin>
                <groupId>org.eclipse.transformer</groupId>
                <artifactId>org.eclipse.transformer.maven</artifactId>
                <version>0.2.2-SNAPSHOT</version>
                <executions>
                    <execution>
                        <phase>process-test-classes</phase>
                        <configuration>
                            <invert>true</invert>
                        </configuration>
                        <goals>
                            <goal>run</goal>
                        </goals>
                    </execution>
                </executions>
            </plugin>
````