### PR TITLE
FISH-6096 CLI Transformer that can Transform Jakarta EE 8 applications to Jakarta EE 10

### DIFF
--- a/org.eclipse.transformer.cli/pom.xml
+++ b/org.eclipse.transformer.cli/pom.xml
@@ -147,11 +147,19 @@
 						<goals>
 							<goal>single</goal>
 						</goals>
-						<configuration>
-							<descriptors>
-								<descriptor>src/assembly/distribution.xml</descriptor>
-							</descriptors>
-						</configuration>
+                                                <configuration>
+                                                    <descriptors>
+                                                        <descriptor>src/assembly/distribution.xml</descriptor>
+                                                    </descriptors>
+                                                    <archive>
+                                                        <manifest>
+                                                            <mainClass>org.eclipse.transformer.jakarta.JakartaTransformer</mainClass>
+                                                        </manifest>
+                                                        <manifestEntries>
+                                                            <Class-Path>${project.build.finalName}.jar</Class-Path>
+                                                        </manifestEntries>
+                                                    </archive>
+                                                </configuration>
 					</execution>
 				</executions>
 			</plugin>


### PR DESCRIPTION
CLI Transformer works to transform EE8 application to EE10.
This PR adds an additional fix to support `org.eclipse.transformer.cli-0.2.8-distribution.jar` and fixes the error `no main manifest attribute, in org.eclipse.transformer.cli/target/org.eclipse.transformer.cli-0.2.8-distribution.jar`.