### PR TITLE
FISH-6729 Eclipse Transformer 0.2.9 and Payara Transformer 1.1.1

### DIFF
--- a/deployment-transformer/deployment-transformer-api/pom.xml
+++ b/deployment-transformer/deployment-transformer-api/pom.xml
@@ -48,7 +48,7 @@
     <parent>
         <groupId>fish.payara.deployment.transformer</groupId>
         <artifactId>deployment-transformer-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>deployment-transformer-api</artifactId>

--- a/deployment-transformer/deployment-transformer-api/pom.xml
+++ b/deployment-transformer/deployment-transformer-api/pom.xml
@@ -48,7 +48,7 @@
     <parent>
         <groupId>fish.payara.deployment.transformer</groupId>
         <artifactId>deployment-transformer-parent</artifactId>
-        <version>1.1</version>
+        <version>1.1.1</version>
     </parent>
 
     <artifactId>deployment-transformer-api</artifactId>

--- a/deployment-transformer/deployment-transformer-impl/pom.xml
+++ b/deployment-transformer/deployment-transformer-impl/pom.xml
@@ -48,7 +48,7 @@
     <parent>
         <groupId>fish.payara.deployment.transformer</groupId>
         <artifactId>deployment-transformer-parent</artifactId>
-        <version>1.1</version>
+        <version>1.1.1</version>
     </parent>
 
     <artifactId>deployment-transformer-impl</artifactId>

--- a/deployment-transformer/deployment-transformer-impl/pom.xml
+++ b/deployment-transformer/deployment-transformer-impl/pom.xml
@@ -48,7 +48,7 @@
     <parent>
         <groupId>fish.payara.deployment.transformer</groupId>
         <artifactId>deployment-transformer-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>deployment-transformer-impl</artifactId>

--- a/deployment-transformer/pom.xml
+++ b/deployment-transformer/pom.xml
@@ -49,7 +49,7 @@
 
     <groupId>fish.payara.deployment.transformer</groupId>
     <artifactId>deployment-transformer-parent</artifactId>
-    <version>1.1</version>
+    <version>1.1.1</version>
 
     <packaging>pom</packaging>
 
@@ -63,9 +63,9 @@
 
         <payara.version>6.2022.1.Alpha4</payara.version>
 
-        <org.eclipse.transformer.payara.version>0.2.8</org.eclipse.transformer.payara.version>
-        <deployment.transformer.api.version>1.1</deployment.transformer.api.version>
-        <deployment.transformer.impl.version>1.1</deployment.transformer.impl.version>
+        <org.eclipse.transformer.payara.version>0.2.9</org.eclipse.transformer.payara.version>
+        <deployment.transformer.api.version>1.1.1</deployment.transformer.api.version>
+        <deployment.transformer.impl.version>1.1.1</deployment.transformer.impl.version>
     </properties>
 
     <distributionManagement>

--- a/deployment-transformer/pom.xml
+++ b/deployment-transformer/pom.xml
@@ -49,7 +49,7 @@
 
     <groupId>fish.payara.deployment.transformer</groupId>
     <artifactId>deployment-transformer-parent</artifactId>
-    <version>1.1.1</version>
+    <version>1.2-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 
@@ -63,9 +63,9 @@
 
         <payara.version>6.2022.1.Alpha4</payara.version>
 
-        <org.eclipse.transformer.payara.version>0.2.9</org.eclipse.transformer.payara.version>
-        <deployment.transformer.api.version>1.1.1</deployment.transformer.api.version>
-        <deployment.transformer.impl.version>1.1.1</deployment.transformer.impl.version>
+        <org.eclipse.transformer.payara.version>0.2.10-SNAPSHOT</org.eclipse.transformer.payara.version>
+        <deployment.transformer.api.version>1.2-SNAPSHOT</deployment.transformer.api.version>
+        <deployment.transformer.impl.version>1.2-SNAPSHOT</deployment.transformer.impl.version>
     </properties>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 	<version>${revision}</version>
 
 	<properties>
-		<revision>0.2.8</revision>
+		<revision>0.2.9</revision>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>8</java.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 	<version>${revision}</version>
 
 	<properties>
-		<revision>0.2.9</revision>
+		<revision>0.2.10-SNAPSHOT</revision>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>8</java.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>


### PR DESCRIPTION
No code changes, just releasing.
The changes of FISH-6096 never got a fix version, and Payara Transformer 1.1 seems to have had something go wrong during its build or publication as the OSGi manifests of the published artefacts are incorrect yet the manifests of a rebuild are correct.

Note that the internal artefacts from 6.2022.1.Alpha4 were never deployed, I am doing so now.