### PR TITLE
FISH-6627 Transformer Works on Payara 6 Enterprise

### DIFF
--- a/deployment-transformer/deployment-transformer-api/pom.xml
+++ b/deployment-transformer/deployment-transformer-api/pom.xml
@@ -66,4 +66,34 @@
         </dependency>
     </dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<version>${maven-bundle-plugin.version}</version>
+				<configuration>
+					<supportedProjectTypes>
+						<supportedProjectType>jar</supportedProjectType>
+					</supportedProjectTypes>
+					<instructions>
+						<Export-Package>
+							fish.payara.deployment.transformer.api.*;version=${deployment.transformer.api.version}
+						</Export-Package>
+					</instructions>
+					<unpackBundle>true</unpackBundle>
+				</configuration>
+				<executions>
+					<execution>
+						<id>osgi-bundle</id>
+						<phase>package</phase>
+						<goals>
+							<goal>bundle</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>

--- a/deployment-transformer/deployment-transformer-api/pom.xml
+++ b/deployment-transformer/deployment-transformer-api/pom.xml
@@ -3,7 +3,7 @@
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-    Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+    Copyright (c) 2022-2023 Payara Foundation and/or its affiliates. All rights reserved.
 
     The contents of this file are subject to the terms of either the GNU
     General Public License Version 2 only ("GPL") or the Common Development
@@ -61,7 +61,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.internal.common</groupId>
+            <groupId>fish.payara.server.core.common</groupId>
             <artifactId>internal-api</artifactId>
         </dependency>
     </dependencies>

--- a/deployment-transformer/deployment-transformer-impl/pom.xml
+++ b/deployment-transformer/deployment-transformer-impl/pom.xml
@@ -92,6 +92,8 @@
 							<instructions>
 								<Import-Package>
 									fish.payara.deployment.transformer.api.*;version=${deployment.transformer.api.version},
+									com.sun.enterprise.util.*;version="[6.0.0,7.0.0)",
+									org.glassfish.api.*;version="[6.0.0,7.0.0)",
 									*
 								</Import-Package>
 								<_include>-osgi.bundle</_include>

--- a/deployment-transformer/deployment-transformer-impl/pom.xml
+++ b/deployment-transformer/deployment-transformer-impl/pom.xml
@@ -3,7 +3,7 @@
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-    Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+    Copyright (c) 2022-2023 Payara Foundation and/or its affiliates. All rights reserved.
 
     The contents of this file are subject to the terms of either the GNU
     General Public License Version 2 only ("GPL") or the Common Development
@@ -61,7 +61,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.internal.common</groupId>
+            <groupId>fish.payara.server.core.common</groupId>
             <artifactId>internal-api</artifactId>
         </dependency>
         <dependency>

--- a/deployment-transformer/deployment-transformer-impl/pom.xml
+++ b/deployment-transformer/deployment-transformer-impl/pom.xml
@@ -74,4 +74,53 @@
         </dependency>
     </dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<version>${maven-bundle-plugin.version}</version>
+				<executions>
+					<execution>
+						<id>default-manifest</id>
+						<phase>process-classes</phase>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<Export-Package />
+							<instructions>
+								<Import-Package>
+									fish.payara.deployment.transformer.api.*;version=${deployment.transformer.api.version},
+									*
+								</Import-Package>
+								<_include>-osgi.bundle</_include>
+							</instructions>
+							<excludeDependencies>tools-jar</excludeDependencies>
+							<supportedProjectTypes>
+								<supportedProjectType>glassfish-jar</supportedProjectType>
+								<supportedProjectType>jar</supportedProjectType>
+							</supportedProjectTypes>
+						</configuration>
+					</execution>
+				</executions>
+				<configuration>
+					<Export-Package />
+					<instructions>
+						<Import-Package>
+							fish.payara.deployment.transformer.api.*;version=${deployment.transformer.api.version},
+							*
+						</Import-Package>
+						<_include>-osgi.bundle</_include>
+					</instructions>
+					<excludeDependencies>tools-jar</excludeDependencies>
+					<supportedProjectTypes>
+						<supportedProjectType>glassfish-jar</supportedProjectType>
+						<supportedProjectType>jar</supportedProjectType>
+					</supportedProjectTypes>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>

--- a/deployment-transformer/pom.xml
+++ b/deployment-transformer/pom.xml
@@ -61,7 +61,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
 
-        <payara.version>6.2023.1</payara.version>
+        <payara.version>6.2023.2</payara.version>
 		<maven-bundle-plugin.version>4.1.0</maven-bundle-plugin.version>
 
         <fish.payara.transformer.payara.version>0.2.11</fish.payara.transformer.payara.version>

--- a/deployment-transformer/pom.xml
+++ b/deployment-transformer/pom.xml
@@ -3,7 +3,7 @@
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-    Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+    Copyright (c) 2022-2023 Payara Foundation and/or its affiliates. All rights reserved.
 
     The contents of this file are subject to the terms of either the GNU
     General Public License Version 2 only ("GPL") or the Common Development
@@ -61,7 +61,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
 
-        <payara.version>6.2022.1.Alpha4</payara.version>
+        <payara.version>6.2023.1</payara.version>
 
         <fish.payara.transformer.payara.version>0.2.11</fish.payara.transformer.payara.version>
         <deployment.transformer.api.version>1.2-SNAPSHOT</deployment.transformer.api.version>
@@ -122,7 +122,7 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>fish.payara.server.internal.common</groupId>
+                <groupId>fish.payara.server.core.common</groupId>
                 <artifactId>internal-api</artifactId>
                 <version>${payara.version}</version>
                 <scope>provided</scope>

--- a/deployment-transformer/pom.xml
+++ b/deployment-transformer/pom.xml
@@ -229,6 +229,9 @@
                         <configuration>
                             <Export-Package />
                             <instructions>
+								<Import-Package>
+									org.glassfish.api.admin;version="[6.0.0,7.0.0)"
+								</Import-Package>
                                 <_include>-osgi.bundle</_include>
                             </instructions>
                             <excludeDependencies>tools-jar</excludeDependencies>
@@ -242,6 +245,9 @@
                 <configuration>
                     <Export-Package />
                     <instructions>
+						<Import-Package>
+							org.glassfish.api.admin;version="[6.0.0,7.0.0)"
+						</Import-Package>
                         <_include>-osgi.bundle</_include>
                     </instructions>
                     <excludeDependencies>tools-jar</excludeDependencies>

--- a/deployment-transformer/pom.xml
+++ b/deployment-transformer/pom.xml
@@ -62,6 +62,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
 
         <payara.version>6.2023.1</payara.version>
+		<maven-bundle-plugin.version>4.1.0</maven-bundle-plugin.version>
 
         <fish.payara.transformer.payara.version>0.2.11</fish.payara.transformer.payara.version>
         <deployment.transformer.api.version>1.2-SNAPSHOT</deployment.transformer.api.version>
@@ -218,7 +219,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>4.1.0</version>
+                <version>${maven-bundle-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>default-manifest</id>


### PR DESCRIPTION
In later Payara versions, `fish.payara.server.internal.common` has moved to `fish.payara.server.core.common`, dependencies have been updated to reflect this.

Previously there was an OSGi Error due to `org.glassfish.api.admin` being 6.2022.0 which is missing as Payara Enterprise provides 6.0.0. Allow anything in the range 6.0.0 _(Inclusive) -_ 7.0.0 _(Exclusive)_ to be provided instead. This allows the same distribution of the transformer to work on Payara 6 Community and Payara 6 Enterprise.

Tested against 6.2023.1 and 6.0.0 deploying clusterjsp.war which contains no jakarta.* imports therefore activating the transformer, deployment is now successful