### PR TITLE
FISH-6627 Transform application_5.xsd

### DIFF
--- a/fish.payara.transformer.cli/src/main/resources/org/eclipse/transformer/jakarta/jakarta-application-xml-dd.properties
+++ b/fish.payara.transformer.cli/src/main/resources/org/eclipse/transformer/jakarta/jakarta-application-xml-dd.properties
@@ -2,4 +2,5 @@
 /application_8.xsd=/application_10.xsd
 /application_7.xsd=/application_10.xsd
 /application_6.xsd=/application_10.xsd
-version\\s*\=\\s*["'][6-9]["']=version="10"
+/application_5.xsd=/application_10.xsd
+version\\s*\=\\s*["'][5-9]["']=version="10"

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 	<version>${revision}</version>
 
 	<properties>
-		<revision>0.2.12-SNAPSHOT</revision>
+		<revision>0.2.12</revision>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>8</java.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 -->
 <!--
 	* Copyright (c) 2020 Contributors to the Eclipse Foundation
-	* Copyright (c) 2022 Payara Foundation and/or its affiliates
+	* Copyright (c) 2022-2023 Payara Foundation and/or its affiliates
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -26,7 +26,7 @@
 	<version>${revision}</version>
 
 	<properties>
-		<revision>0.2.11</revision>
+		<revision>0.2.12-SNAPSHOT</revision>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>8</java.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>


### PR DESCRIPTION
Quicklook has a test which uses `application_5.xsd` in the META-INF/application.xml file. When the deployment transformer was bundled in this app failed to deploy as it expected namespace 'https://jakarta.ee/xml/ns/jakartaee', but the target namespace of the schema document is 'http://java.sun.com/xml/ns/javaee'

Tested and quicklook now passes