### PR TITLE
FISH-7553 Transform Applications After Upgrade

### DIFF
--- a/deployment-transformer/deployment-transformer-api/pom.xml
+++ b/deployment-transformer/deployment-transformer-api/pom.xml
@@ -48,7 +48,7 @@
     <parent>
         <groupId>fish.payara.deployment.transformer</groupId>
         <artifactId>deployment-transformer-parent</artifactId>
-        <version>1.2</version>
+        <version>1.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>deployment-transformer-api</artifactId>
@@ -64,6 +64,10 @@
             <groupId>fish.payara.server.core.common</groupId>
             <artifactId>internal-api</artifactId>
         </dependency>
+		<dependency>
+			<groupId>fish.payara.server.core.deployment</groupId>
+			<artifactId>deployment-common</artifactId>
+		</dependency>
     </dependencies>
 
 	<build>

--- a/deployment-transformer/deployment-transformer-api/src/main/java/fish/payara/deployment/transformer/api/JakartaNamespaceDeploymentTransformer.java
+++ b/deployment-transformer/deployment-transformer-api/src/main/java/fish/payara/deployment/transformer/api/JakartaNamespaceDeploymentTransformer.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022-2023 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/deployment-transformer/deployment-transformer-api/src/main/java/fish/payara/deployment/transformer/api/JakartaNamespaceDeploymentTransformer.java
+++ b/deployment-transformer/deployment-transformer-api/src/main/java/fish/payara/deployment/transformer/api/JakartaNamespaceDeploymentTransformer.java
@@ -40,16 +40,22 @@
 package fish.payara.deployment.transformer.api;
 
 import org.glassfish.api.admin.AdminCommandContext;
+import org.glassfish.deployment.common.DeploymentException;
 import org.glassfish.hk2.classmodel.reflect.Types;
+import org.glassfish.internal.deployment.ExtendedDeploymentContext;
 
 import java.io.File;
 import java.io.IOException;
 
 public interface JakartaNamespaceDeploymentTransformer {
 
+	@Deprecated
     File transformApplication(File path, AdminCommandContext context, boolean isDirectoryDeployed) throws IOException;
 
+	@Deprecated
     File transformApplication(File path, AdminCommandContext context, boolean isDirectoryDeployed, boolean invert) throws IOException;
+
+	File transformApplication(ExtendedDeploymentContext deploymentContext) throws IOException, DeploymentException;
 
     boolean isJakartaEEApplication(Types types);
 

--- a/deployment-transformer/deployment-transformer-impl/pom.xml
+++ b/deployment-transformer/deployment-transformer-impl/pom.xml
@@ -48,7 +48,7 @@
     <parent>
         <groupId>fish.payara.deployment.transformer</groupId>
         <artifactId>deployment-transformer-parent</artifactId>
-        <version>1.2</version>
+        <version>1.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>deployment-transformer-impl</artifactId>
@@ -68,6 +68,10 @@
             <groupId>fish.payara.deployment.transformer</groupId>
             <artifactId>deployment-transformer-api</artifactId>
         </dependency>
+		<dependency>
+			<groupId>fish.payara.server.core.deployment</groupId>
+			<artifactId>deployment-common</artifactId>
+		</dependency>
         <dependency>
             <groupId>fish.payara.transformer</groupId>
             <artifactId>fish.payara.transformer.payara</artifactId>
@@ -88,12 +92,13 @@
 							<goal>manifest</goal>
 						</goals>
 						<configuration>
-							<Export-Package />
 							<instructions>
 								<Import-Package>
 									fish.payara.deployment.transformer.api.*;version=${deployment.transformer.api.version},
 									com.sun.enterprise.util.*;version="[6.0.0,7.0.0)",
 									org.glassfish.api.*;version="[6.0.0,7.0.0)",
+									org.glassfish.deployment.*;version="[6.0.0,7.0.0)",
+									org.glassfish.internal.deployment.*;version="[6.0.0,7.0.0)",
 									*
 								</Import-Package>
 								<_include>-osgi.bundle</_include>
@@ -106,21 +111,6 @@
 						</configuration>
 					</execution>
 				</executions>
-				<configuration>
-					<Export-Package />
-					<instructions>
-						<Import-Package>
-							fish.payara.deployment.transformer.api.*;version=${deployment.transformer.api.version},
-							*
-						</Import-Package>
-						<_include>-osgi.bundle</_include>
-					</instructions>
-					<excludeDependencies>tools-jar</excludeDependencies>
-					<supportedProjectTypes>
-						<supportedProjectType>glassfish-jar</supportedProjectType>
-						<supportedProjectType>jar</supportedProjectType>
-					</supportedProjectTypes>
-				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/deployment-transformer/deployment-transformer-impl/src/main/java/fish/payara/deployment/transformer/JakartaNamespaceDeploymentTransformerImpl.java
+++ b/deployment-transformer/deployment-transformer-impl/src/main/java/fish/payara/deployment/transformer/JakartaNamespaceDeploymentTransformerImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2020-2022 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020-2023 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/deployment-transformer/pom.xml
+++ b/deployment-transformer/pom.xml
@@ -49,7 +49,7 @@
 
     <groupId>fish.payara.deployment.transformer</groupId>
     <artifactId>deployment-transformer-parent</artifactId>
-    <version>1.2</version>
+    <version>1.3-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 
@@ -65,8 +65,8 @@
 		<maven-bundle-plugin.version>4.1.0</maven-bundle-plugin.version>
 
         <fish.payara.transformer.payara.version>0.2.13</fish.payara.transformer.payara.version>
-        <deployment.transformer.api.version>1.2</deployment.transformer.api.version>
-        <deployment.transformer.impl.version>1.2</deployment.transformer.impl.version>
+        <deployment.transformer.api.version>1.3-SNAPSHOT</deployment.transformer.api.version>
+        <deployment.transformer.impl.version>1.3-SNAPSHOT</deployment.transformer.impl.version>
     </properties>
 
     <distributionManagement>
@@ -128,6 +128,12 @@
                 <version>${payara.version}</version>
                 <scope>provided</scope>
             </dependency>
+			<dependency>
+				<groupId>fish.payara.server.core.deployment</groupId>
+				<artifactId>deployment-common</artifactId>
+				<version>${payara.version}</version>
+				<scope>provided</scope>
+			</dependency>
             <dependency>
                 <groupId>fish.payara.transformer</groupId>
                 <artifactId>fish.payara.transformer.payara</artifactId>
@@ -228,7 +234,6 @@
                             <goal>manifest</goal>
                         </goals>
                         <configuration>
-                            <Export-Package />
                             <instructions>
 								<Import-Package>
 									org.glassfish.api.admin;version="[6.0.0,7.0.0)"
@@ -244,7 +249,6 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <Export-Package />
                     <instructions>
 						<Import-Package>
 							org.glassfish.api.admin;version="[6.0.0,7.0.0)"


### PR DESCRIPTION
The current placement of the Jakarta transformer means that it only takes effect on the deploy/redeploy command; applications already deployed are not checked if they need transforming upon server start. This means when upgrading from Payara 5 the Jakarta EE 8 applications are not transformed.

This PR adjusts the transformer to be a part of the `prepare` phase of the `ApplicationLifecycle` - happening directly after class scanning.

As a part of this, I've deprecated the original methods as they're not used anymore.