### PR TITLE
Fish 7752 bug fix eclipse deleting folders

### DIFF
--- a/fish.payara.transformer.maven/src/main/java/org/eclipse/transformer/maven/TransformMojo.java
+++ b/fish.payara.transformer.maven/src/main/java/org/eclipse/transformer/maven/TransformMojo.java
@@ -10,7 +10,7 @@
  ********************************************************************************/
 
 // Copyright (c) 2020 Contributors to the Eclipse Foundation
-// Copyright (c) 2022 Payara Foundation and/or its affiliates
+// Copyright (c) 2022-2023 Payara Foundation and/or its affiliates
 
 package org.eclipse.transformer.maven;
 

--- a/fish.payara.transformer.maven/src/main/java/org/eclipse/transformer/maven/TransformMojo.java
+++ b/fish.payara.transformer.maven/src/main/java/org/eclipse/transformer/maven/TransformMojo.java
@@ -163,12 +163,10 @@ public class TransformMojo extends AbstractMojo {
 			throw new MojoFailureException("Transformer failed with an error: " + Transformer.RC_DESCRIPTIONS[rc]);
 		}
 
-		if (TARGET_AS_ORIGIN.equals(classifier)) {
+		if (TARGET_AS_ORIGIN.equals(classifier) && !isSourceAndTargetAvailable()) {
 			try {
 				if (sourceArtifact.getFile().isDirectory()) {
-					if(!isSourceAndTargetEquals()) {
-						FileUtils.deleteDirectory(sourceArtifact.getFile());
-					}
+					FileUtils.deleteDirectory(sourceArtifact.getFile());
 				} else {
 					targetFile.delete();
 				}
@@ -239,12 +237,10 @@ public class TransformMojo extends AbstractMojo {
 		transformer.setArgs(args.toArray(new String[0]));
 		int rc = transformer.run();
 
-		if (TARGET_AS_ORIGIN.equals(classifier)) {
+		if (TARGET_AS_ORIGIN.equals(classifier) && !isSourceAndTargetAvailable()) {
 			try {
 				if (source.isDirectory()) {
-					if(!isSourceAndTargetEquals()) {
-						FileUtils.deleteDirectory(source);
-					}
+					FileUtils.deleteDirectory(source);
 				} else {
 					source.delete();
 				}
@@ -257,12 +253,11 @@ public class TransformMojo extends AbstractMojo {
 			throw new MojoFailureException("Transformer failed with an error: " + Transformer.RC_DESCRIPTIONS[rc]);
 		}
 	}
-
-	private boolean isSourceAndTargetEquals() {
+	private boolean isSourceAndTargetAvailable() {
 		Properties properties = System.getProperties();
 		String selectedSource = properties.getProperty(SELECTED_SOURCE);
 		String selectedTarget = properties.getProperty(SELECTED_TARGET);
-		return selectedSource != null && selectedTarget != null && selectedSource.equals(selectedTarget);
+		return selectedSource != null && selectedTarget != null;
 	}
 
 	/**

--- a/fish.payara.transformer.maven/src/test/java/org/eclipse/transformer/maven/TransformMojoTest.java
+++ b/fish.payara.transformer.maven/src/test/java/org/eclipse/transformer/maven/TransformMojoTest.java
@@ -10,7 +10,7 @@
  ********************************************************************************/
 
 // Copyright (c) 2020 Contributors to the Eclipse Foundation
-// Copyright (c) 2022 Payara Foundation and/or its affiliates
+// Copyright (c) 2022-2023 Payara Foundation and/or its affiliates
 
 package org.eclipse.transformer.maven;
 

--- a/fish.payara.transformer.maven/src/test/java/org/eclipse/transformer/maven/TransformMojoTest.java
+++ b/fish.payara.transformer.maven/src/test/java/org/eclipse/transformer/maven/TransformMojoTest.java
@@ -19,10 +19,12 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.model.Build;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 import org.apache.maven.plugin.testing.MojoRule;
 import org.apache.maven.plugin.testing.stubs.DefaultArtifactHandlerStub;
@@ -188,6 +190,10 @@ public class TransformMojoTest extends AbstractMojoTestCase {
 		assertTrue(pom.exists());
 
 		MavenProject mavenProject = createMavenProject(pom, "pom", "simple-service");
+		Build build = createBuild();
+		mavenProject.setBuild(build);
+		MavenProjectHelper mavenProjectHelper = new ProjectHelper();
+		mojo.setProjectHelper(mavenProjectHelper);
 		mojo.setProject(mavenProject);
 		mojo.setClassifier("transformed");
 		System.setProperty("selectedSource", getTestFile("src/test/resources/HelloResource.java").getAbsolutePath());
@@ -195,8 +201,8 @@ public class TransformMojoTest extends AbstractMojoTestCase {
 		Transformer transformer = mojo.getTransformer();
 		String[] args = {mojo.getSelectedSource(), mojo.getSelectedTarget()};
 		transformer.setArgs(args);
-		mojo.setMainSource(true);
-		mojo.setTestSource(false);
+		mojo.setMainSource(false);
+		mojo.setTestSource(true);
 		mojo.setInvert(false);
 		mojo.setOverwrite(true);
 		assertNotNull(transformer);
@@ -235,6 +241,10 @@ public class TransformMojoTest extends AbstractMojoTestCase {
 		assertTrue(pom.exists());
 
 		MavenProject mavenProject = createMavenProject(pom, "pom", "simple-service");
+		Build build = createBuild();
+		mavenProject.setBuild(build);
+		MavenProjectHelper mavenProjectHelper = new ProjectHelper();
+		mojo.setProjectHelper(mavenProjectHelper);
 		mojo.setProject(mavenProject);
 		mojo.setClassifier("transformed");
 		System.setProperty("selectedSource", getTestFile("src/test/resources/sourceFiles").getAbsolutePath());
@@ -242,8 +252,8 @@ public class TransformMojoTest extends AbstractMojoTestCase {
 		Transformer transformer = mojo.getTransformer();
 		String[] args = {mojo.getSelectedSource(), mojo.getSelectedTarget()};
 		transformer.setArgs(args);
-		mojo.setMainSource(true);
-		mojo.setTestSource(false);
+		mojo.setMainSource(false);
+		mojo.setTestSource(true);
 		mojo.setInvert(false);
 		mojo.setOverwrite(true);
 		assertNotNull(transformer);
@@ -259,6 +269,10 @@ public class TransformMojoTest extends AbstractMojoTestCase {
 		assertTrue(pom.exists());
 
 		MavenProject mavenProject = createMavenProject(pom, "pom", "simple-service");
+		Build build = createBuild();
+		mavenProject.setBuild(build);
+		MavenProjectHelper mavenProjectHelper = new ProjectHelper();
+		mojo.setProjectHelper(mavenProjectHelper);
 		mojo.setProject(mavenProject);
 		mojo.setClassifier("transformed");
 		createProcessDirectory();
@@ -267,8 +281,8 @@ public class TransformMojoTest extends AbstractMojoTestCase {
 		Transformer transformer = mojo.getTransformer();
 		String[] args = {mojo.getSelectedSource(), mojo.getSelectedTarget()};
 		transformer.setArgs(args);
-		mojo.setMainSource(true);
-		mojo.setTestSource(false);
+		mojo.setMainSource(false);
+		mojo.setTestSource(true);
 		mojo.setInvert(false);
 		mojo.setOverwrite(true);
 		assertNotNull(transformer);
@@ -334,6 +348,13 @@ public class TransformMojoTest extends AbstractMojoTestCase {
 		return mavenProject;
 	}
 
+	public Build createBuild() {
+		Build build = new Build();
+		build.setTestOutputDirectory("src/temp");
+		build.setSourceDirectory("src/test");
+		return build;
+	}
+
 	public File createService() throws IOException {
 		final File tempFile = File.createTempFile("service", ".war");
 		tempFile.delete();
@@ -342,5 +363,33 @@ public class TransformMojoTest extends AbstractMojoTestCase {
 		webArchive.as(ZipExporter.class)
 			.exportTo(tempFile, true);
 		return tempFile;
+	}
+
+	class ProjectHelper implements MavenProjectHelper {
+
+		@Override
+		public void attachArtifact(MavenProject mavenProject, File file, String s) {
+
+		}
+
+		@Override
+		public void attachArtifact(MavenProject mavenProject, String s, File file) {
+
+		}
+
+		@Override
+		public void attachArtifact(MavenProject mavenProject, String s, String s1, File file) {
+
+		}
+
+		@Override
+		public void addResource(MavenProject mavenProject, String s, List<String> list, List<String> list1) {
+
+		}
+
+		@Override
+		public void addTestResource(MavenProject mavenProject, String s, List<String> list, List<String> list1) {
+
+		}
 	}
 }

--- a/fish.payara.transformer.maven/src/test/projects/transform-build-artifact/pom.xml
+++ b/fish.payara.transformer.maven/src/test/projects/transform-build-artifact/pom.xml
@@ -46,7 +46,7 @@
             <plugin>
                 <groupId>fish.payara.transformer</groupId>
                 <artifactId>fish.payara.transformer.maven</artifactId>
-                <version>0.2.14</version>
+                <version>0.2.15-SNAPSHOT</version>
                 <configuration>
 
                 </configuration>

--- a/fish.payara.transformer.maven/src/test/projects/transform-build-artifact/pom.xml
+++ b/fish.payara.transformer.maven/src/test/projects/transform-build-artifact/pom.xml
@@ -46,7 +46,7 @@
             <plugin>
                 <groupId>fish.payara.transformer</groupId>
                 <artifactId>fish.payara.transformer.maven</artifactId>
-                <version>0.2.13</version>
+                <version>0.2.13-SNAPSHOT</version>
                 <configuration>
 
                 </configuration>

--- a/fish.payara.transformer.maven/src/test/projects/transform-build-artifact/pom.xml
+++ b/fish.payara.transformer.maven/src/test/projects/transform-build-artifact/pom.xml
@@ -46,7 +46,7 @@
             <plugin>
                 <groupId>fish.payara.transformer</groupId>
                 <artifactId>fish.payara.transformer.maven</artifactId>
-                <version>0.2.14-SNAPSHOT</version>
+                <version>0.2.14</version>
                 <configuration>
 
                 </configuration>

--- a/fish.payara.transformer.maven/src/test/projects/transform-build-artifact/pom.xml
+++ b/fish.payara.transformer.maven/src/test/projects/transform-build-artifact/pom.xml
@@ -11,7 +11,7 @@
 -->
 <!--
 	* Copyright (c) 2020 Contributors to the Eclipse Foundation
-	* Copyright (c) 2022 Payara Foundation and/or its affiliates
+	* Copyright (c) 2022-2023 Payara Foundation and/or its affiliates
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -46,7 +46,7 @@
             <plugin>
                 <groupId>fish.payara.transformer</groupId>
                 <artifactId>fish.payara.transformer.maven</artifactId>
-                <version>0.2.13-SNAPSHOT</version>
+                <version>0.2.14-SNAPSHOT</version>
                 <configuration>
 
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 	<version>${revision}</version>
 
 	<properties>
-		<revision>0.2.13-SNAPSHOT</revision>
+		<revision>0.2.14-SNAPSHOT</revision>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>8</java.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 	<version>${revision}</version>
 
 	<properties>
-		<revision>0.2.14</revision>
+		<revision>0.2.15-SNAPSHOT</revision>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>8</java.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 	<version>${revision}</version>
 
 	<properties>
-		<revision>0.2.14-SNAPSHOT</revision>
+		<revision>0.2.14</revision>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>8</java.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 	<version>${revision}</version>
 
 	<properties>
-		<revision>0.2.13</revision>
+		<revision>0.2.13-SNAPSHOT</revision>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>8</java.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>


### PR DESCRIPTION
This is the PR to add bug fix for eclipse transformer plugin caused by deleting local source folder of a project when transforming

Tests done:

Manual testing using the command to transform to different folder:
`mvn fish.payara.transformer:fish.payara.transformer.maven:0.2.14:run -DselectedSource=C:\Users\alfon\Downloads\SameSiteTesterEE8 -DselectedTarget=C:\java\temp\transform
`

with success and without affecting the source code from the original project:
`
INFORMACIËN: Action selected for input [ C:/Users/alfon/Downloads/SameSiteTesterEE8 ]: Directory Action
ago. 30, 2023 10:59:23 P.áM. org.eclipse.transformer.action.impl.ContainerChangesImpl displayTerse
INFORMACIËN: Input [ {} ] as [ {} ]: {}
ago. 30, 2023 10:59:23 P.áM. org.eclipse.transformer.action.impl.ContainerChangesImpl displayTerse
INFORMACIËN: [          All Resources ] [     44 ] Unselected [      0 ] Selected [     44 ]
ago. 30, 2023 10:59:23 P.áM. org.eclipse.transformer.action.impl.ContainerChangesImpl displayTerse
INFORMACIËN: [            All Actions ] [     44 ]  Unchanged [     29 ]  Changed [     15 ]
ago. 30, 2023 10:59:23 P.áM. org.eclipse.transformer.action.impl.ContainerChangesImpl displayTerse
INFORMACIËN: [       Nested Resources ] [   2432 ] Unselected [      0 ] Selected [   2432 ]
ago. 30, 2023 10:59:23 P.áM. org.eclipse.transformer.action.impl.ContainerChangesImpl displayTerse
INFORMACIËN: [         Nested Actions ] [   2432 ]  Unchanged [    334 ]  Changed [   2098 ]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  2.166 s
[INFO] Finished at: 2023-08-30T22:59:23-05:00
[INFO] ------------------------------------------------------------------------
`

![image](https://github.com/payara/transformer/assets/279375/4b5d8447-fb31-406a-97b6-225a9c1de6aa)

also tested with netbeans plugin:

![image](https://github.com/payara/transformer/assets/279375/441b507e-e53f-4666-8673-c8d28e67b2f5)

![image](https://github.com/payara/transformer/assets/279375/e2db1e25-32b7-49b1-adbe-748dab3b7571)


![image](https://github.com/payara/transformer/assets/279375/6ebdabcd-e1ec-46dc-909e-b6db0461bce8)

source folder not affected, this issue didn't affect netbeans implementation but it was needed to do regression tests