### PR TITLE
FISH-8328 Expand OSGi Range

### DIFF
--- a/deployment-transformer/deployment-transformer-api/pom.xml
+++ b/deployment-transformer/deployment-transformer-api/pom.xml
@@ -3,7 +3,7 @@
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-    Copyright (c) 2022-2023 Payara Foundation and/or its affiliates. All rights reserved.
+    Copyright (c) 2022-2024 Payara Foundation and/or its affiliates. All rights reserved.
 
     The contents of this file are subject to the terms of either the GNU
     General Public License Version 2 only ("GPL") or the Common Development
@@ -69,35 +69,5 @@
 			<artifactId>deployment-common</artifactId>
 		</dependency>
     </dependencies>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.felix</groupId>
-				<artifactId>maven-bundle-plugin</artifactId>
-				<version>${maven-bundle-plugin.version}</version>
-				<configuration>
-					<supportedProjectTypes>
-						<supportedProjectType>jar</supportedProjectType>
-					</supportedProjectTypes>
-					<instructions>
-						<Export-Package>
-							fish.payara.deployment.transformer.api.*;version=${deployment.transformer.api.version}
-						</Export-Package>
-					</instructions>
-					<unpackBundle>true</unpackBundle>
-				</configuration>
-				<executions>
-					<execution>
-						<id>osgi-bundle</id>
-						<phase>package</phase>
-						<goals>
-							<goal>bundle</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/deployment-transformer/deployment-transformer-impl/pom.xml
+++ b/deployment-transformer/deployment-transformer-impl/pom.xml
@@ -3,7 +3,7 @@
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-    Copyright (c) 2022-2023 Payara Foundation and/or its affiliates. All rights reserved.
+    Copyright (c) 2022-2024 Payara Foundation and/or its affiliates. All rights reserved.
 
     The contents of this file are subject to the terms of either the GNU
     General Public License Version 2 only ("GPL") or the Common Development
@@ -83,34 +83,18 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>${maven-bundle-plugin.version}</version>
-				<executions>
-					<execution>
-						<id>default-manifest</id>
-						<phase>process-classes</phase>
-						<goals>
-							<goal>manifest</goal>
-						</goals>
-						<configuration>
-							<instructions>
-								<Import-Package>
-									fish.payara.deployment.transformer.api.*;version=${deployment.transformer.api.version},
-									com.sun.enterprise.util.*;version="[6.0.0,7.0.0)",
-									org.glassfish.api.*;version="[6.0.0,7.0.0)",
-									org.glassfish.deployment.*;version="[6.0.0,7.0.0)",
-									org.glassfish.internal.deployment.*;version="[6.0.0,7.0.0)",
-									*
-								</Import-Package>
-								<_include>-osgi.bundle</_include>
-							</instructions>
-							<excludeDependencies>tools-jar</excludeDependencies>
-							<supportedProjectTypes>
-								<supportedProjectType>glassfish-jar</supportedProjectType>
-								<supportedProjectType>jar</supportedProjectType>
-							</supportedProjectTypes>
-						</configuration>
-					</execution>
-				</executions>
+				<configuration>
+					<instructions>
+						<Import-Package>
+							fish.payara.deployment.transformer.api.*;version=${deployment.transformer.api.version},
+							com.sun.enterprise.util.*;version="[6.0.0,7.0.0]",
+							org.glassfish.api.*;version="[6.0.0,7.0.0]",
+							org.glassfish.deployment.*;version="[6.0.0,7.0.0]",
+							org.glassfish.internal.deployment.*;version="[6.0.0,7.0.0]",
+							*
+						</Import-Package>
+					</instructions>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/deployment-transformer/pom.xml
+++ b/deployment-transformer/pom.xml
@@ -57,6 +57,8 @@
     <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
         <java.version>11</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/deployment-transformer/pom.xml
+++ b/deployment-transformer/pom.xml
@@ -3,7 +3,7 @@
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-    Copyright (c) 2022-2023 Payara Foundation and/or its affiliates. All rights reserved.
+    Copyright (c) 2022-2024 Payara Foundation and/or its affiliates. All rights reserved.
 
     The contents of this file are subject to the terms of either the GNU
     General Public License Version 2 only ("GPL") or the Common Development
@@ -194,6 +194,27 @@
                         <outputDirectory>${project.build.directory}</outputDirectory>
                     </configuration>
                 </plugin>
+				<plugin>
+					<groupId>org.apache.felix</groupId>
+					<artifactId>maven-bundle-plugin</artifactId>
+					<version>${maven-bundle-plugin.version}</version>
+					<configuration>
+						<instructions>
+							<Import-Package>
+								org.glassfish.api.admin;version="[6.0.0,7.0.0]",
+								org.glassfish.deployment.common;version="[6.0.0,7.0.0]",
+								org.glassfish.internal.deployment;version="[6.0.0,7.0.0]",
+								*
+							</Import-Package>
+							<_include>-osgi.bundle</_include>
+						</instructions>
+						<excludeDependencies>tools-jar</excludeDependencies>
+						<supportedProjectTypes>
+							<supportedProjectType>glassfish-jar</supportedProjectType>
+							<supportedProjectType>jar</supportedProjectType>
+						</supportedProjectTypes>
+					</configuration>
+				</plugin>
             </plugins>
         </pluginManagement>
 
@@ -226,41 +247,6 @@
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <version>${maven-bundle-plugin.version}</version>
-                <executions>
-                    <execution>
-                        <id>default-manifest</id>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>manifest</goal>
-                        </goals>
-                        <configuration>
-                            <instructions>
-								<Import-Package>
-									org.glassfish.api.admin;version="[6.0.0,7.0.0)"
-								</Import-Package>
-                                <_include>-osgi.bundle</_include>
-                            </instructions>
-                            <excludeDependencies>tools-jar</excludeDependencies>
-                            <supportedProjectTypes>
-                                <supportedProjectType>glassfish-jar</supportedProjectType>
-                                <supportedProjectType>jar</supportedProjectType>
-                            </supportedProjectTypes>
-                        </configuration>
-                    </execution>
-                </executions>
-                <configuration>
-                    <instructions>
-						<Import-Package>
-							org.glassfish.api.admin;version="[6.0.0,7.0.0)"
-						</Import-Package>
-                        <_include>-osgi.bundle</_include>
-                    </instructions>
-                    <excludeDependencies>tools-jar</excludeDependencies>
-                    <supportedProjectTypes>
-                        <supportedProjectType>glassfish-jar</supportedProjectType>
-                        <supportedProjectType>jar</supportedProjectType>
-                    </supportedProjectTypes>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.glassfish.hk2</groupId>

--- a/deployment-transformer/pom.xml
+++ b/deployment-transformer/pom.xml
@@ -78,12 +78,12 @@
         <repository>
             <id>payara-nexus-artifacts</id>
             <name>Payara Nexus Artifacts</name>
-            <url>https://nexus.dev.payara.fish/content/repositories/payara-artifacts</url>
+            <url>https://nexus.dev.payara.fish/repository/payara-artifacts</url>
         </repository>
 		<snapshotRepository>
 			<id>payara-nexus-snapshots</id>
 			<name>Payara Nexus Snapshots</name>
-			<url>https://nexus.dev.payara.fish/content/repositories/payara-snapshots</url>
+			<url>https://nexus.dev.payara.fish/repository/payara-snapshots</url>
 		</snapshotRepository>
     </distributionManagement>
 

--- a/deployment-transformer/pom.xml
+++ b/deployment-transformer/pom.xml
@@ -63,10 +63,15 @@
 
         <payara.version>6.2023.2</payara.version>
         <maven-bundle-plugin.version>4.1.0</maven-bundle-plugin.version>
+		<maven-javadoc-plugin.version>3.6.3</maven-javadoc-plugin.version>
+		<maven-source-plugin.version>3.3.0</maven-source-plugin.version>
 
         <fish.payara.transformer.payara.version>0.2.13</fish.payara.transformer.payara.version>
         <deployment.transformer.api.version>1.4-SNAPSHOT</deployment.transformer.api.version>
         <deployment.transformer.impl.version>1.4-SNAPSHOT</deployment.transformer.impl.version>
+
+		<javadoc.skip>false</javadoc.skip>
+		<source.skip>false</source.skip>
     </properties>
 
     <distributionManagement>
@@ -228,6 +233,24 @@
 						</supportedProjectTypes>
 					</configuration>
 				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-javadoc-plugin</artifactId>
+					<version>${maven-javadoc-plugin.version}</version>
+					<configuration>
+						<detectOfflineLinks>false</detectOfflineLinks>
+						<skip>${javadoc.skip}</skip>
+					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-source-plugin</artifactId>
+					<version>${maven-source-plugin.version}</version>
+					<configuration>
+						<includePom>true</includePom>
+						<skipSource>${source.skip}</skipSource>
+					</configuration>
+				</plugin>
             </plugins>
         </pluginManagement>
 
@@ -294,6 +317,31 @@
                     <versionPropertyName>project.osgi.version</versionPropertyName>
                 </configuration>
             </plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>jar-no-fork</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
         </plugins>
     </build>
 

--- a/deployment-transformer/pom.xml
+++ b/deployment-transformer/pom.xml
@@ -75,6 +75,11 @@
             <name>Payara Nexus Artifacts</name>
             <url>https://nexus.dev.payara.fish/content/repositories/payara-artifacts</url>
         </repository>
+		<snapshotRepository>
+			<id>payara-nexus-snapshots</id>
+			<name>Payara Nexus Snapshots</name>
+			<url>https://nexus.dev.payara.fish/content/repositories/payara-snapshots</url>
+		</snapshotRepository>
     </distributionManagement>
 
     <repositories>
@@ -88,6 +93,16 @@
                 <enabled>false</enabled>
             </snapshots>
         </repository>
+		<repository>
+			<id>payara-nexus-snapshots</id>
+			<url>https://nexus.dev.payara.fish/repository/payara-snapshots</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
     </repositories>
 
     <pluginRepositories>
@@ -101,18 +116,16 @@
                 <enabled>false</enabled>
             </snapshots>
         </pluginRepository>
-        <!-- Needed for glassfishbuild-maven-plugin 3.2.20.payara-p2 -->
-        <pluginRepository>
-            <id>payara-patched-externals</id>
-            <name>Payara Patched Externals</name>
-            <url>https://raw.github.com/payara/Payara_PatchedProjects/master</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </pluginRepository>
+		<pluginRepository>
+			<id>payara-nexus-snapshots</id>
+			<url>https://nexus.dev.payara.fish/repository/payara-snapshots</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</pluginRepository>
     </pluginRepositories>
 
     <modules>


### PR DESCRIPTION
Expands the OSGi range from [6.0.0,7.0.0) to [6.0.0,7.0.0] for testing purposes.
Also does some cleanup, adds javadoc & source generation, defines snapshot repository, and fixes the distribution repo URL.

Really needs a test of the actual transformer itself.